### PR TITLE
Fix the GRPC sample

### DIFF
--- a/samples/GRPC/Program.cs
+++ b/samples/GRPC/Program.cs
@@ -11,7 +11,7 @@ builder.Services.AddGrpc();
 
 var app = builder.Build();
 
-app.Listen("http://localhost:3000");
+app.Listen("https://localhost:3000");
 
 app.MapGrpcService<GreeterService>();
 


### PR DESCRIPTION
Checked this out to kick the tires, discovered a miniscule bug in the GRPC sample that causes it to not work by default (server listens for HTTP, client listens / requires HTTPS).